### PR TITLE
support multiple grammars

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,10 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "env": {
+    "test": {
+      "plugins": [
+        "babel-plugin-rewire"
+      ]
+    }
+  }
 }

--- a/README.md
+++ b/README.md
@@ -28,3 +28,10 @@
 import grammar from 'file.ohm'
 grammar.match(...);
 ```
+
+or if the file contains more than one grammar
+
+```javascript
+import {CSV, Json} from 'file.ohm'
+CSV.match(...);
+```

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-jest": "^21.2.0",
+    "babel-plugin-rewire": "^1.1.0",
     "babel-preset-es2015": "^6.24.1",
     "eslint": "^4.10.0",
     "jest": "^21.2.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,25 @@
 import ohm from 'ohm-js';
 
+
+const createGrammars = (ohm, recipes) => {
+  for (let recipeKey in recipes) {
+    recipes[recipeKey] = ohm.makeRecipe(recipes[recipeKey]);
+  }
+  if (Object.keys(recipes).length == 1) {
+    return Object.values(recipes)[0];
+  }
+  return recipes;
+};
+
 export default function (rawGrammar) {
   if (this.cacheable) {
     this.cacheable();
   }
 
-  const grammar = ohm.grammar(rawGrammar);
-  return `module.exports = require('ohm-js').makeRecipe(${grammar.toRecipe()});`;
+  const namespace = ohm.grammars(rawGrammar);
+  for (let grammarName in namespace) {
+    namespace[grammarName] = namespace[grammarName].toRecipe();
+  }
+
+  return `module.exports = (${createGrammars})(require('ohm-js'), ${JSON.stringify(namespace)});`;
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,8 +3,12 @@ import ohm from 'ohm-js';
 import loader from '../src';
 
 const getExpectedOutput = (input) => {
-  const grammar = ohm.grammar(input);
-  return `module.exports = require('ohm-js').makeRecipe(${grammar.toRecipe()});`;
+  const namespace = ohm.grammars(input);
+  for (let grammarName in namespace) {
+    namespace[grammarName] = namespace[grammarName].toRecipe()
+  }
+
+  return `module.exports = (${loader.__get__('createGrammars')})(require('ohm-js'), ${JSON.stringify(namespace)});`;
 };
 
 describe('loader tests', () => {


### PR DESCRIPTION
Hello!
I am using this loader in a small project of mine, and the only feature lacking was support for multiple grammars defined in one file. I've implemented it for myself and took the liberty of making a pull request.
The changes are non-breaking. 
When there is a single grammar in the file being loaded, only this grammar will be exported. If there's more than one grammar in the file, all of them will be exported by their respective names. 